### PR TITLE
style: @gsm.hs.kr 위에 input이 올라가도록 수정

### DIFF
--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -18,6 +18,7 @@ export default function LoginPage() {
   const [emailCheck, setEmailCheck] = useState<boolean>(false);
   const [pwCheck, setPwCheck] = useState<boolean>(false);
   const [error, setError] = useState<number>(200);
+  const [loginTitleWidth, setLoginTitleWidth] = useState<number>(50);
   const viewWidth = useRecoilValue(ViewWidth);
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement[]>([]);
@@ -25,6 +26,22 @@ export default function LoginPage() {
   const isQuery =
     router.query.client_id !== undefined &&
     router.query.redirect_uri !== undefined;
+
+  const makeTitleSize = () => {
+    setLoginTitleWidth(() => {
+      if (window.innerWidth > 550) return 45;
+      return (
+        (window.innerWidth * 4) /
+        5 /
+        ((serviceNameRef.current?.innerText.length ?? 16) - 1)
+      );
+    });
+  };
+
+  useEffect(() => {
+    makeTitleSize();
+    addEventListener('resize', () => makeTitleSize());
+  }, [serviceName, setServiceName]);
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -97,7 +114,7 @@ export default function LoginPage() {
           {serviceName === '' ? (
             <h1>Login</h1>
           ) : (
-            <S.LoginName>
+            <S.LoginName width={loginTitleWidth}>
               <span>GAuth</span> 계정으로
               <br />
               <span ref={serviceNameRef}>{serviceName}에 로그인</span>

--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -174,7 +174,9 @@ export default function LoginPage() {
             <S.Submit onClick={onLogin}>로그인</S.Submit>
             <div>
               <Link href="/signUp">회원가입</Link> <span>l</span>{' '}
-              <Link href="/initPassword">비밀번호 찾기</Link>
+              <a onClick={() => toast.info('다음 버전에 추가할 예정')}>
+                비밀번호 찾기
+              </a>
             </div>
           </S.ButtonContainer>
         </S.LoginContainer>

--- a/src/components/LoginPage/style.ts
+++ b/src/components/LoginPage/style.ts
@@ -251,7 +251,7 @@ export const Email = styled.div`
   top: -50px;
   left: 60%;
   font-size: 27px;
-  z-index: 100;
+  z-index: -1;
 
   @media (max-width: 1200px) {
     color: #fff;

--- a/src/components/LoginPage/style.ts
+++ b/src/components/LoginPage/style.ts
@@ -11,8 +11,13 @@ export const Layer = styled.div`
   display: flex;
 
   @media (max-width: 1200px) {
-    margin-top: 5%;
+    margin-top: 5vh;
     height: 95%;
+  }
+
+  @media (max-width: 600px) {
+    margin-top: 12vh;
+    height: 88%;
   }
 `;
 
@@ -180,13 +185,15 @@ export const LoginContainer = styled.div`
 
 export const LoginName = styled.h2`
   text-align: center;
-  font-size: 50px;
-  max-height: 150px;
-  white-space: nowrap;
+  font-size: ${({ width }: { width: number }) => {
+    return `${width}px`;
+  }};
+  max-height: 3.6em;
+  word-break: keep-all;
+  -webkit-line-clamp: 3;
 
   @media (max-width: 1200px) {
     color: #fff;
-    font-size: 45px;
   }
 
   span:nth-of-type(1) {


### PR DESCRIPTION
## 💡 개요
- email input에서 "@gsm.hs.kr"를 클릭(터치)하면 아무 반응이 없음
- 다양한 서비스명의 길이에 맞는 반응형 Login Form Title(Gauth 계정으로...)이 필요
## 📃 작업내용
- ["@gsm.hs.kr"를 투명한 배경인 input 뒤에 위치](https://github.com/GSM-MSG/GAUTH-frontend/commit/83c2ee023e3fc210be2e209e7f290066f7a3609c)
- [Login Form Title에 반응형 추가](https://github.com/GSM-MSG/GAUTH-frontend/commit/0c4a11a6ca594a2505d2ba0023bb9b883a4b96ac)
![image](https://user-images.githubusercontent.com/87346613/211859164-8547a93d-3cb5-4937-883e-8b13c88e51ae.png)
![image](https://user-images.githubusercontent.com/87346613/211859620-b7f91385-39c4-4403-a252-025fc6d5bf7e.png)
