### PR TITLE
🔀 로그인 페이지 라우팅 방식 수정

### DIFF
--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -12,6 +12,7 @@ import { toast } from 'react-toastify';
 import { useForm } from 'react-hook-form';
 import { LoginFormProps } from '../../types';
 import API from '../../api';
+import { client_id, redirect_uri } from '../../lib/OauthQuery';
 
 export default function LoginPage() {
   const [serviceName, setServiceName] = useState<string>('');
@@ -24,6 +25,7 @@ export default function LoginPage() {
   const isQuery =
     router.query.client_id !== undefined &&
     router.query.redirect_uri !== undefined;
+  const signUpUri = `/signup?${client_id}=${router.query[client_id]}&${redirect_uri}=${router.query[redirect_uri]}`;
 
   const { register, handleSubmit, getValues } = useForm<LoginFormProps>({
     mode: 'onSubmit',
@@ -96,6 +98,19 @@ export default function LoginPage() {
     return toast.warn(Object.values(err)[0].message);
   };
 
+  const onRouting = () => {
+    router.push(
+      {
+        pathname: '/signUp',
+        query: {
+          client_id: router.query[client_id],
+          redirect_uri: router.query[redirect_uri],
+        },
+      },
+      '/signUp'
+    );
+  };
+
   return (
     <S.Layer>
       <SideWave />
@@ -156,7 +171,10 @@ export default function LoginPage() {
           <S.ButtonContainer>
             <S.Submit type="submit">로그인</S.Submit>
             <div>
-              <Link href="/signUp">회원가입</Link> <span>l</span>{' '}
+              <button type="button" onClick={onRouting}>
+                회원가입
+              </button>{' '}
+              <span>l</span>{' '}
               <a onClick={() => toast.info('다음 버전에 추가할 예정')}>
                 비밀번호 찾기
               </a>

--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -25,7 +25,6 @@ export default function LoginPage() {
   const isQuery =
     router.query.client_id !== undefined &&
     router.query.redirect_uri !== undefined;
-  const signUpUri = `/signup?${client_id}=${router.query[client_id]}&${redirect_uri}=${router.query[redirect_uri]}`;
 
   const { register, handleSubmit, getValues } = useForm<LoginFormProps>({
     mode: 'onSubmit',

--- a/src/components/LoginPage/style.ts
+++ b/src/components/LoginPage/style.ts
@@ -311,6 +311,10 @@ export const ButtonContainer = styled.div`
 
   div > * {
     color: #929292;
+    background: none;
+    font-size: 1em;
+    cursor: pointer;
+
     @media (max-width: 1320px) {
       color: #fff;
     }

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -10,6 +10,8 @@ import { toast } from 'react-toastify';
 import { AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import API from '../../api';
+import { useRouter } from 'next/router';
+import { client_id, redirect_uri } from '../../lib/OauthQuery';
 
 export default function SignUpPage() {
   const formDefaultValues = {
@@ -29,6 +31,7 @@ export default function SignUpPage() {
   const { register, watch, setValue, setFocus, reset } = useForm({
     defaultValues: formDefaultValues,
   });
+  const router = useRouter();
 
   const resetStateHandler = () => {
     reset(formDefaultValues);
@@ -74,6 +77,16 @@ export default function SignUpPage() {
       }
       if (e.response?.status === 500) return toast.error('error');
     }
+  };
+
+  const onRouting = () => {
+    router.push({
+      pathname: '/login',
+      query: {
+        client_id: router.query[client_id],
+        redirect_uri: router.query[redirect_uri],
+      },
+    });
   };
 
   return (
@@ -161,7 +174,10 @@ export default function SignUpPage() {
                   다음
                 </S.Submit>
                 <div>
-                  <Link href="/login">로그인</Link> |{' '}
+                  <button type="button" onClick={onRouting}>
+                    로그인
+                  </button>{' '}
+                  |{' '}
                   <a
                     onClick={() => {
                       toast.info('다음 버전에 추가될 예정');
@@ -216,7 +232,10 @@ export default function SignUpPage() {
                       다음
                     </S.ChangeBtn>
                   </div>
-                  <Link href="/login">로그인</Link> |{' '}
+                  <button type="button" onClick={onRouting}>
+                    로그인
+                  </button>{' '}
+                  |{' '}
                   <a
                     onClick={() => {
                       toast.info('다음 버전에 추가될 예정');

--- a/src/components/SignUpPage/style.ts
+++ b/src/components/SignUpPage/style.ts
@@ -277,6 +277,12 @@ export const ButtonContainer = styled.div`
     @media (max-width: 600px) {
       font-size: 14px;
     }
+
+    > button {
+      background: none;
+      font-size: 1em;
+      cursor: pointer;
+    }
   }
 `;
 
@@ -454,6 +460,11 @@ export const ProfileBtnWrapper = styled.div`
   color: #929292;
   @media (max-width: 1200px) {
     color: #fff;
+  }
+  > button {
+    background: none;
+    font-size: 1em;
+    cursor: pointer;
   }
   div {
     display: flex;

--- a/src/components/SignUpPage/style.ts
+++ b/src/components/SignUpPage/style.ts
@@ -282,6 +282,10 @@ export const ButtonContainer = styled.div`
       background: none;
       font-size: 1em;
       cursor: pointer;
+
+      @media (max-width: 1200px) {
+        color: #fff;
+      }
     }
   }
 `;
@@ -465,6 +469,10 @@ export const ProfileBtnWrapper = styled.div`
     background: none;
     font-size: 1em;
     cursor: pointer;
+
+    @media (max-width: 1200px) {
+      color: #fff;
+    }
   }
   div {
     display: flex;

--- a/src/lib/OauthQuery.ts
+++ b/src/lib/OauthQuery.ts
@@ -1,0 +1,2 @@
+export const client_id = 'client_id';
+export const redirect_uri = 'redirect_uri';


### PR DESCRIPTION
## 💡 개요
oauth 로그인 페이지에서 회원가입 페이지로 간 후 로그인 페이지로 가면 oauth 로그인이 아닌 gauth 사이트 로그인으로 바뀌는데 oauth 로그인 페이지로 가는게 자연스럽다고 생각하여 수정했습니다.

## 📃 작업내용
- 로그인 페이지에서 query(client_id, redirect_uri)가 존재하면 회원가입 페이지로 이동 시 query를 담아가고
회원가입 페이지에서 query가 존재하면 로그인 페이지로 이동 시 query를 담도록 수정했습니다.

## 🙋‍♂️ 질문사항
uri에 query가 보이지 않도록 할까요? uri에 query가 있으면 지저분한 것 같긴 합니다