### PR TITLE
🔀로그인 form에서 이메일 maxLength 삭제

### DIFF
--- a/src/components/LoginPage/index.tsx
+++ b/src/components/LoginPage/index.tsx
@@ -134,7 +134,6 @@ export default function LoginPage() {
                   onBlur: () =>
                     getValues('email') === '' && setEmailCheck(false),
                 })}
-                maxLength={6}
                 onFocus={() => setEmailCheck(true)}
               />
               <S.Email>@gsm.hs.kr</S.Email>


### PR DESCRIPTION
## 💡 개요
선생님 계정은 이메일 길이가 자유로워 maxLength를 삭제합니다