### PR TITLE
🔀 Portal Add stopPropagation

### DIFF
--- a/src/components/common/Portal/index.tsx
+++ b/src/components/common/Portal/index.tsx
@@ -1,9 +1,15 @@
-import { useState, ReactNode, useEffect } from 'react';
+import {
+  useState,
+  useEffect,
+  ReactElement,
+  MouseEvent,
+  cloneElement,
+} from 'react';
 import ReactDOM from 'react-dom';
 import { Positioner } from './style';
 
 type Props = {
-  children: ReactNode;
+  children: ReactElement;
   onClose: () => void;
 };
 
@@ -25,8 +31,14 @@ const Portal = ({ children, onClose }: Props) => {
 
   if (!isMounted) return null;
 
+  const onClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
   return ReactDOM.createPortal(
-    <Positioner onClick={onClose}>{children}</Positioner>,
+    <Positioner onClick={onClose}>
+      {cloneElement(children, { onClick })}
+    </Positioner>,
     document.getElementById('portal')!
   );
 };


### PR DESCRIPTION
## 💡 개요
포탈컴포넌트에서 자식 컴포넌트를 눌러도 포탈 컴포넌트가 닫히는 버그 발생

## 📃 작업내용
* 자식 컴포넌트 이벤트 발생시 stopPropagation 추가
