### PR TITLE
🔀 비밀번호 체크 기능 추가

### DIFF
--- a/src/components/NewSignIn/index.tsx
+++ b/src/components/NewSignIn/index.tsx
@@ -21,6 +21,7 @@ export default function NewSignInPage() {
     router.query[client_id] !== undefined &&
     router.query[redirect_uri] !== undefined;
   const [serviceName, setServiceName] = useState('');
+  const [checkPassword, setCheckPassword] = useState(true);
   const [error, setError] = useState('');
   const { checkAuto } = useAutoLogin(false);
 
@@ -58,7 +59,7 @@ export default function NewSignInPage() {
     if (isQuery) {
       getService();
     } else {
-      checkAuto && router.push('/'); 
+      checkAuto && router.push('/');
     }
     return;
   }, [checkAuto, isQuery, router]);
@@ -124,7 +125,11 @@ export default function NewSignInPage() {
                 },
                 maxLength: 72,
               })}
-              type="password"
+              type={checkPassword ? undefined : 'password'}
+              fixed={checkPassword ? '닫기' : '보기'}
+              fixedHandle={() => {
+                setCheckPassword((prev) => !prev);
+              }}
             />
             {error && <p>{error}</p>}
           </S.InputWrapper>

--- a/src/components/NewSignIn/index.tsx
+++ b/src/components/NewSignIn/index.tsx
@@ -21,7 +21,7 @@ export default function NewSignInPage() {
     router.query[client_id] !== undefined &&
     router.query[redirect_uri] !== undefined;
   const [serviceName, setServiceName] = useState('');
-  const [checkPassword, setCheckPassword] = useState(true);
+  const [checkPassword, setCheckPassword] = useState(false);
   const [error, setError] = useState('');
   const { checkAuto } = useAutoLogin(false);
 
@@ -124,6 +124,9 @@ export default function NewSignInPage() {
                     '영어,숫자,특수문자를 각각 하나 이상 포함한 8자 이상 72자 이하 형식을 맞춰주세요',
                 },
                 maxLength: 72,
+                onChange() {
+                  setCheckPassword(false);
+                },
               })}
               type={checkPassword ? undefined : 'password'}
               fixed={checkPassword ? '닫기' : '보기'}

--- a/src/components/common/Auth/NewPasswordCommon.tsx
+++ b/src/components/common/Auth/NewPasswordCommon.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRecoilState } from 'recoil';
@@ -28,6 +27,7 @@ export default function NewPasswordCommon({
 }: Props) {
   const [emailInfo, setEmailInfo] = useRecoilState(EmailInfo);
   const [error, setError] = useState('');
+  const [checkPassword, setCheckPassword] = useState(true);
   const { changeModalType } = useResetModal();
   const setModalType = () => {
     if (!changeModal) return;
@@ -64,7 +64,7 @@ export default function NewPasswordCommon({
       <Form onSubmit={handleSubmit(setPassword)}>
         <InputWrapper>
           <Input
-            type="password"
+            type={checkPassword ? undefined : 'password'}
             label={`${newPassword ? '새' : ''} 비밀번호`}
             errors={!!errors.password}
             message={errors.password?.message}
@@ -77,6 +77,10 @@ export default function NewPasswordCommon({
               },
               maxLength: 72,
             })}
+            fixed={checkPassword ? '닫기' : '보기'}
+            fixedHandle={() => {
+              setCheckPassword((prev) => !prev);
+            }}
           />
           <Input
             type="password"

--- a/src/components/common/Auth/NewPasswordCommon.tsx
+++ b/src/components/common/Auth/NewPasswordCommon.tsx
@@ -27,7 +27,7 @@ export default function NewPasswordCommon({
 }: Props) {
   const [emailInfo, setEmailInfo] = useRecoilState(EmailInfo);
   const [error, setError] = useState('');
-  const [checkPassword, setCheckPassword] = useState(true);
+  const [checkPassword, setCheckPassword] = useState(false);
   const { changeModalType } = useResetModal();
   const setModalType = () => {
     if (!changeModal) return;
@@ -76,6 +76,9 @@ export default function NewPasswordCommon({
                   '영어,숫자,특수문자를 각각 하나 이상 포함한 8자 이상 72자 이하 형식을 맞춰주세요',
               },
               maxLength: 72,
+              onChange() {
+                setCheckPassword(false);
+              },
             })}
             fixed={checkPassword ? '닫기' : '보기'}
             fixedHandle={() => {

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   register?: UseFormRegisterReturn;
   type?: string;
   fixed?: string;
+  fixedHandle?: () => void;
 }
 
 export default function Input({
@@ -17,6 +18,7 @@ export default function Input({
   register,
   type = 'text',
   fixed,
+  fixedHandle,
 }: Props) {
   return (
     <S.Wrapper>
@@ -27,7 +29,12 @@ export default function Input({
       </S.Label>
       <S.InputWrapper>
         <S.Input type={type} {...register} autoComplete="on" />
-        <S.FixedInputValue>{fixed}</S.FixedInputValue>
+        <S.FixedInputValue
+          cursor={!!fixedHandle}
+          onClick={() => fixedHandle && fixedHandle()}
+        >
+          {fixed}
+        </S.FixedInputValue>
       </S.InputWrapper>
     </S.Wrapper>
   );

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react';
 import { UseFormRegisterReturn } from 'react-hook-form';
 import * as S from './style';
 
@@ -7,7 +8,7 @@ interface Props {
   message?: string;
   register?: UseFormRegisterReturn;
   type?: string;
-  fixed?: string;
+  fixed?: string | ReactElement;
   fixedHandle?: () => void;
 }
 

--- a/src/components/common/Input/style.ts
+++ b/src/components/common/Input/style.ts
@@ -41,4 +41,5 @@ export const FixedInputValue = styled.div`
   transform: translateY(-50%);
   color: #a6a6a6;
   font-size: 0.85em;
+  cursor: ${({ cursor }: { cursor: boolean }) => cursor && 'pointer'};
 `;


### PR DESCRIPTION
## 💡 개요
비밀번호 input type이 passowrd여서 입력하다 생각이 안나면 클라이언트가 곤란 해질수도 있다고 판단

## 📃 작업내용
* password 입력부분에 passwordcheck기능 추가
* common input props fixed에 react element타입 추가

<img width="381" alt="image" src="https://user-images.githubusercontent.com/81688137/224565020-66ed6002-7c80-478d-8aee-8b69efb8a697.png">

<img width="369" alt="image" src="https://user-images.githubusercontent.com/81688137/224565025-4e3af32b-a774-4f3c-96bc-9795a8a53cdc.png">

