### PR TITLE
🔀설명 페이지의 코드블럭 디자인 수정

### DIFF
--- a/src/components/InstructionPage/style.ts
+++ b/src/components/InstructionPage/style.ts
@@ -22,12 +22,19 @@ export const Wrapper = styled.div`
   width: 1200px;
   font-size: 20px;
 
+  pre {
+    background: transparent;
+  }
+  code {
+    color: #000;
+  }
+
   @media (max-width: 1400px) {
     width: 100%;
     margin: 0 50px 50px;
 
     > * {
-      font-size: 1.4vw;
+      font-size: 1.125vw;
     }
   }
 `;


### PR DESCRIPTION
## 💡 개요
설명페이지의 코드블럭이 어색해서 수정했습니다

## 📃 작업내용
- 코드블럭의 style을 수정했습니다

| 변경 전 | 변경 후 |
|---------|----------|
| ![image](https://user-images.githubusercontent.com/87346613/227814646-620d4018-b64f-4e84-bc8f-19ae030a73fa.png) | ![image](https://user-images.githubusercontent.com/87346613/227814700-ddc84e53-a7d9-477c-a4aa-3affc42d91ec.png) |

---
- 설명 페이지의 text의 반응형이 자연스럽게 보이도록 수정했습니다
## 🙋‍♂️ 질문사항
이보다 더 나은 디자인이 있다고 생각하면 comment 남겨주세요!

