### PR TITLE
🔀 Stulist 전체 조회 기능 추가

### DIFF
--- a/src/Atom/Atoms.tsx
+++ b/src/Atom/Atoms.tsx
@@ -57,8 +57,8 @@ export const Filter = atom<StulistFilterType>({
   key: 'filter',
   default: {
     role: 'ROLE_STUDENT',
-    grade: '1',
-    classNum: '1',
+    grade: '0',
+    classNum: '0',
   },
 });
 

--- a/src/components/common/StuListFilter/index.tsx
+++ b/src/components/common/StuListFilter/index.tsx
@@ -1,17 +1,19 @@
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
+import * as SVG from '../../../../public/svg';
 import { Filter } from '../../../Atom/Atoms';
 import { FilterList } from '../../../lib/FilterList';
 import Item from './Item';
 import * as S from './style';
-import * as SVG from '../../../../public/svg';
-import { useState } from 'react';
 
 export default function SideBar() {
   const [filter, setFilter] = useRecoilState(Filter);
   const [menuActive, setMenuActive] = useState(false);
 
-  const onChange = (name: string, value: string) => {
-    setFilter((prev) => {
+  const onChange = (name: 'role' | 'grade' | 'classNum', value: string) => {
+    return setFilter((prev) => {
+      if (prev[name] === value && name !== 'role')
+        return { ...prev, [name]: '0' };
       return { ...prev, [name]: value };
     });
   };

--- a/src/components/common/StuListFilter/index.tsx
+++ b/src/components/common/StuListFilter/index.tsx
@@ -3,6 +3,7 @@ import { useRecoilState } from 'recoil';
 import * as SVG from '../../../../public/svg';
 import { Filter } from '../../../Atom/Atoms';
 import { FilterList } from '../../../lib/FilterList';
+import { FilterOptionType } from '../../../types/components/Sidebar';
 import Item from './Item';
 import * as S from './style';
 
@@ -10,7 +11,7 @@ export default function SideBar() {
   const [filter, setFilter] = useRecoilState(Filter);
   const [menuActive, setMenuActive] = useState(false);
 
-  const onChange = (name: 'role' | 'grade' | 'classNum', value: string) => {
+  const onChange = (name: FilterOptionType, value: string) => {
     return setFilter((prev) => {
       if (prev[name] === value && name !== 'role')
         return { ...prev, [name]: '0' };

--- a/src/types/components/Sidebar.ts
+++ b/src/types/components/Sidebar.ts
@@ -1,0 +1,1 @@
+export type FilterOptionType = 'role' | 'grade' | 'classNum';


### PR DESCRIPTION
## 💡 개요
- 어드민 페이지의 Stulist에서 학년/반을 선택하면 선택 해제가 되지 않았습니다.
- Stulist에서 전체 조회를 할 수 없었습니다.
## 📃 작업내용
- Stulist의 atom default 값을 변경했습니다.
- 학년/반 선택 해제 기능을 추가했습니다.
