### PR TITLE
🔀 Sidebar 라우팅 오류 수정

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -51,7 +51,9 @@ export default function Sidebar() {
                   pathname={pathname === navData.url}
                   key={navData.url}
                 >
-                  <Link href={navData.url}>{navData.svg}</Link>
+                  <Link href={navData.url}>
+                    <a>{navData.svg}</a>
+                  </Link>
                 </S.MenuWrapper>
               );
             })}


### PR DESCRIPTION
## 💡 개요
next13에서는 `<Link>` 태그만 써도 라우팅이 되지만 v12에서는 <Link> 태그만으로는 라우팅을 할 수가 없어서 오류가 발생했습니다.
## 📃 작업내용
`<Link>` 태그 안에 `<a>` 태그를 추가했습니다.
