### PR TITLE
modify filtering location

### DIFF
--- a/src/components/common/StuListFilter/style.ts
+++ b/src/components/common/StuListFilter/style.ts
@@ -13,7 +13,7 @@ export const SideBar = styled.div`
   background: #ffffff;
   border: 1px solid #e4e4e4;
   border-radius: 10px;
-  padding: 20px 20px 36px;
+  padding: 25px 13px 25px 40px;
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
## 💡 개요
재학생, 졸업생, 선생님 유저 필터링의 위치가 왼쪽으로 치우쳐져 오른쪽 너비가 부각된다는 이슈가 있었음
## 📃 작업내용
<img width="122" alt="스크린샷 2023-06-26 오후 8 28 25" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/101445027/c13fc232-36bf-4107-b654-bd9cc1de57eb">

보다시피 글자를 조금더 중앙으로 옮김
## 🔀 변경사항
필터링 내부 패팅 크기가 달라짐