### PR TITLE
wrap alarm svg

### DIFF
--- a/src/components/Stulist/Header/index.tsx
+++ b/src/components/Stulist/Header/index.tsx
@@ -23,7 +23,9 @@ export default function Header() {
         <h1>사용자 관리</h1>
       </div>
       <Link href={'?type=applicant'}>
-        <SVG.Alarm />
+        <div>
+          <SVG.Alarm />
+        </div>
       </Link>
     </S.Header>
   );

--- a/src/components/common/StuListFilter/style.ts
+++ b/src/components/common/StuListFilter/style.ts
@@ -13,7 +13,7 @@ export const SideBar = styled.div`
   background: #ffffff;
   border: 1px solid #e4e4e4;
   border-radius: 10px;
-  padding: 25px 13px 25px 40px;
+  padding: 25px 15px 25px 40px;
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
## 💡 개요
알람 svg를 클릭했을 때 applicant로 이동이 안됐음
## 📃 작업내용
<img width="677" alt="스크린샷 2023-06-29 오후 5 24 15" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/101445027/2e26a913-24ad-4321-8983-308dd5481703">

## 🔀 변경사항
svg를 div로 한번 감쌌음
