### PR TITLE
🔀 등록한 서비스가 없을 때 삭제버튼 hide 처리

### DIFF
--- a/src/components/MyServiceList/index.tsx
+++ b/src/components/MyServiceList/index.tsx
@@ -32,33 +32,34 @@ export default function MyServiceList() {
           <S.Title>내가 등록한 서비스</S.Title>
         )}
 
-        {user.clientList.length !== 0 && deleteState ? (
-          <S.DeleteContainer>
-            <S.Delete
-              onClick={() =>
-                serviceCheckList.length > 0 &&
-                setFix((prev) => {
-                  return {
-                    ...prev,
-                    type: 'delete',
-                  };
-                })
-              }
-            >
-              삭제
-            </S.Delete>
-            <S.Delete
-              onClick={() => {
-                setDeleteState(false);
-                setServiceCheckList([]);
-              }}
-            >
-              취소
-            </S.Delete>
-          </S.DeleteContainer>
-        ) : (
-          <S.Delete onClick={() => setDeleteState(true)}>삭제</S.Delete>
-        )}
+        {user.clientList.length !== 0 &&
+          (deleteState ? (
+            <S.DeleteContainer>
+              <S.Delete
+                onClick={() =>
+                  serviceCheckList.length > 0 &&
+                  setFix((prev) => {
+                    return {
+                      ...prev,
+                      type: 'delete',
+                    };
+                  })
+                }
+              >
+                삭제
+              </S.Delete>
+              <S.Delete
+                onClick={() => {
+                  setDeleteState(false);
+                  setServiceCheckList([]);
+                }}
+              >
+                취소
+              </S.Delete>
+            </S.DeleteContainer>
+          ) : (
+            <S.Delete onClick={() => setDeleteState(true)}>삭제</S.Delete>
+          ))}
       </S.TitleContainer>
       {user.clientList.length !== 0 ? (
         <S.ListWrapper>

--- a/src/components/MyServiceList/index.tsx
+++ b/src/components/MyServiceList/index.tsx
@@ -29,7 +29,7 @@ export default function MyServiceList() {
         {deleteState ? (
           <S.Title>서비스 삭제</S.Title>
         ) : (
-          <S.Title>내가 등록한 서비스</S.Title>
+          <S.Title>내 서비스</S.Title>
         )}
 
         {user.clientList.length !== 0 &&


### PR DESCRIPTION
## 💡 개요
등록한 서비스가 없을 때에도 삭제 버튼이 존재함
## 📃 작업내용
내 서비스가 없을 땐 삭제 버튼이 존재하지 않게 수정했습니다
<img width="1680" alt="image" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/103751430/87d61a63-df6e-4de4-95b4-0a21d8a857d1">

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
