### PR TITLE
🔀 서비스명 수정에서 제한 글자 수 초과시 에러메시지 출력

### DIFF
--- a/src/components/MyProfilePage/style.ts
+++ b/src/components/MyProfilePage/style.ts
@@ -5,7 +5,6 @@ export const Layout = styled.div`
   min-height: 100vh;
   display: flex;
   justify-content: center;
-
   @media (min-width: 801px) {
     padding-left: 100px;
   }
@@ -25,7 +24,7 @@ export const Wrapper = styled.div`
 
 export const TitleSection = styled.div`
   width: 100%;
-  margin-top: 2vw;
+  margin-top: 6vw;
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/src/components/MyServiceList/Modify/index.tsx
+++ b/src/components/MyServiceList/Modify/index.tsx
@@ -135,24 +135,30 @@ export default function ModifyMyService() {
                 label={'리다이렉트 URI'}
                 errors={!!errors.error}
                 register={register('redirectUri', {
-                  required: '사이트 URI를 입력하지 않았습니다.',
+                  required: '리다이렉트 URI를 입력하지 않았습니다.',
                   pattern: {
                     value: regUri,
                     message: '리다이렉트 URI를 형식에 맞게 입력해주세요',
                   },
-                  maxLength: 254,
+                  maxLength: {
+                    value: 254,
+                    message: '리다이렉트 URI는 254자 미만이어야 합니다.',
+                  },
                 })}
               />
               <Input
                 label={'서비스 URI'}
                 errors={!!errors.error}
                 register={register('serviceUri', {
-                  required: '사이트 URI를 입력하지 않았습니다.',
+                  required: '서비스 URI를 입력하지 않았습니다.',
                   pattern: {
                     value: regUri,
-                    message: '사이트 URI를 형식에 맞게 입력해주세요',
+                    message: '서비스 URI를 형식에 맞게 입력해주세요',
                   },
-                  maxLength: 254,
+                  maxLength: {
+                    value: 254,
+                    message: '서비스 URI는 254자 미만이어야 합니다.',
+                  },
                 })}
               />
             </div>

--- a/src/components/MyServiceList/Modify/index.tsx
+++ b/src/components/MyServiceList/Modify/index.tsx
@@ -124,9 +124,13 @@ export default function ModifyMyService() {
                     value: /\S+/,
                     message: '서비스명을 입력하지 않았습니다.',
                   },
-                  maxLength: 29,
+                  maxLength: {
+                    value: 29,
+                    message: '서비스명은 30자 미만이어야 합니다.',
+                  },
                 })}
               />
+
               <Input
                 label={'리다이렉트 URI'}
                 errors={!!errors.error}


### PR DESCRIPTION
## 💡 개요
서비스명을 수정할 때 글자 수 초과시 빈 toast가 출력되는 이슈 존재
## 📃 작업내용
- 제한 글자 수를 초과할 때 출력 에러메시지를 추가했습니다.
<img width="1290" alt="image" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/103751430/ac04e217-7a0e-46b9-be43-5f4e955723de">

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
