### PR TITLE
🔀회원가입 이메일 input 정규식 변경

### DIFF
--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -138,7 +138,7 @@ export default function NewSignInPage() {
               register={register('email', {
                 required: '이메일을 입력하지 않았습니다',
                 pattern: {
-                  value: /^[a-zA-Z0-9]*$/g,
+                  value: /^[a-zA-Z0-9\.]*$/g,
                   message: 'GSM메일 형식에 맞게 입력해주세요',
                 },
               })}

--- a/src/components/common/Auth/NewPasswordCommon.tsx
+++ b/src/components/common/Auth/NewPasswordCommon.tsx
@@ -103,7 +103,7 @@ export default function NewPasswordCommon({
                 },
               },
             })}
-            maxLength={72}
+            maxLength={72}비
           />
           {error && <p>{error}</p>}
         </InputWrapper>

--- a/src/components/common/Auth/NewPasswordCommon.tsx
+++ b/src/components/common/Auth/NewPasswordCommon.tsx
@@ -103,7 +103,7 @@ export default function NewPasswordCommon({
                 },
               },
             })}
-            maxLength={72}비
+            maxLength={72}
           />
           {error && <p>{error}</p>}
         </InputWrapper>

--- a/src/components/common/Auth/SearchEmail.tsx
+++ b/src/components/common/Auth/SearchEmail.tsx
@@ -69,7 +69,7 @@ export default function SearchEmail({ title }: Props) {
               register={register('email', {
                 required: '이메일을 입력하지 않았습니다',
                 pattern: {
-                  value: /^[a-zA-Z0-9]*$/g,
+                  value: /^[a-zA-Z0-9\.]*$/g,
                   message: 'GSM메일 형식에 맞게 입력해주세요',
                 },
               })}


### PR DESCRIPTION
## 💡 개요
이메일 앞부분에 '.'이 들어갔음
## 📃 작업내용
<img width="301" alt="스크린샷 2023-11-08 오후 11 33 23" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/101445027/3bb919a4-ed28-49cf-bc34-15e97d262b7d">

정규식을 수정하여 이메일 input value를 제한함
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
