### PR TITLE
🐛 Fix null exception about PrivacySection at user profile

### DIFF
--- a/src/components/MyProfilePage/Profile.tsx
+++ b/src/components/MyProfilePage/Profile.tsx
@@ -79,7 +79,9 @@ export default function Profile() {
       <S.PrivacySection>
         <h1>{user.name}</h1>
         <p>
-          {user.grade + '학년 ' + user.classNum + '반 ' + user.number + '번'}
+          {!user.grade && !user.classNum && !user.number
+                ? '졸업생'
+                : `${user.grade}학년 ${user.classNum}반 ${user.number}번`}
         </p>
         <h3>{user.email}</h3>
       </S.PrivacySection>


### PR DESCRIPTION
## 💡 개요

#191 

## 📃 작업내용

졸업생들은 학년, 반, 번호에 대한 정보가 없기때문에 null로 노출되는 점에 대해서 `졸업생`으로 표기되게끔 변경

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
