### PR TITLE
🔀 공동작업자 기능 및 디자인적 오류 해결

### DIFF
--- a/src/components/MyServiceList/Modify/Assignment/index.tsx
+++ b/src/components/MyServiceList/Modify/Assignment/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { ErrorIcon } from '../../../../../public/svg';
 import useFetch from '../../../../hooks/useFetch';
 import Portal from '../../../common/Portal';
@@ -10,12 +11,14 @@ interface Props {
 }
 
 export default function Assignment({ onClose, modifyId, userId }: Props) {
+  const router = useRouter();
 
   const { fetch } = useFetch({
     url: `client/${modifyId}/owner?userId=${userId}`,
     method: 'patch',
     onSuccess: () => {
       onClose();
+      router.push('/myprofile');
     },
   });
 

--- a/src/components/MyServiceList/Modify/CoWorkerModal/index.tsx
+++ b/src/components/MyServiceList/Modify/CoWorkerModal/index.tsx
@@ -7,8 +7,6 @@ import SearchBar from '../../../common/SearchBar';
 import * as S from './style';
 import useFetch from '../../../../hooks/useFetch';
 import { toast } from 'react-toastify';
-import DeleteAssignment from '../DeleteAssignment';
-import Assignment from '../Assignment';
 import {
   ServiceOwnerModal,
   ServiceDeleteModal,
@@ -18,13 +16,14 @@ import {
 interface Props {
   onClose: () => void;
   modifyId: string;
+  setStuId: (id: number) => void;
 }
 
 interface Worker {
   userId: number;
 }
 
-export default function ServiceCoWorkersList({ onClose, modifyId }: Props) {
+export default function ServiceCoWorkersList({ onClose, modifyId, setStuId }: Props) {
   const search = useRecoilValue(Search);
   const stuList = useRecoilValue(StuList);
   const [workers, setWorkers] = useState<Worker[]>([]);
@@ -50,28 +49,13 @@ export default function ServiceCoWorkersList({ onClose, modifyId }: Props) {
     getCoWorkers();
   }, [modifyId]);
 
-  const closeModal = () => {
-    setServiceOwnerModal('');
-    setServiceDeleteModal('');
-    setServiceRetrieveModal('');
-  };
-
   const roleSwitcher = (event: ChangeEvent<HTMLSelectElement>, id: number) => {
     const select = event.target.value;
+    setStuId(id);
     if (select === 'delete') {
       setServiceDeleteModal('assignment');
-      return (
-        <Assignment onClose={closeModal} modifyId={modifyId} userId={id} />
-      );
     } else if (select === 'owner') {
       setServiceOwnerModal('assignment');
-      return (
-        <DeleteAssignment
-          onClose={closeModal}
-          modifyId={modifyId}
-          userId={id}
-        />
-      );
     }
   };
 
@@ -95,12 +79,12 @@ export default function ServiceCoWorkersList({ onClose, modifyId }: Props) {
                 <th>번호</th>
               </S.TR>
             </thead>
-            <S.TBody>
+            <tbody>
               {stuList
                 .filter((e) => e.name?.includes(search))
                 .filter((e) => workers.some((person) => e.id === person.userId))
                 .map((e) => (
-                  <tr key={e.id}>
+                  <S.TR key={e.id}>
                     <td>{e.name}</td>
                     <td>{e.grade}</td>
                     <td>{e.classNum}</td>
@@ -118,9 +102,9 @@ export default function ServiceCoWorkersList({ onClose, modifyId }: Props) {
                         <option value="delete">삭제</option>
                       </select>
                     </td>
-                  </tr>
+                  </S.TR>
                 ))}
-            </S.TBody>
+            </tbody>
           </S.Table>
         </S.TableWrapper>
       </S.Container>

--- a/src/components/MyServiceList/Modify/CoWorkerModal/style.ts
+++ b/src/components/MyServiceList/Modify/CoWorkerModal/style.ts
@@ -73,6 +73,7 @@ export const TR = styled.tr`
   font-size: 14px;
   line-height: 17px;
   color: #1c1c1c;
+  border-top: 1px solid #e4e4e4;
 
   th {
     font-weight: 500;
@@ -105,12 +106,3 @@ export const TR = styled.tr`
   }
 `;
 
-export const TBody = styled.tbody`
-  tr {
-    border-top: 1px solid #e4e4e4;
-  }
-
-  select {
-    width: 80px;
-  }
-`;

--- a/src/components/MyServiceList/Modify/DeleteAssignment/index.tsx
+++ b/src/components/MyServiceList/Modify/DeleteAssignment/index.tsx
@@ -3,6 +3,8 @@ import { ErrorIcon } from '../../../../../public/svg';
 import useFetch from '../../../../hooks/useFetch';
 import Portal from '../../../common/Portal';
 import * as S from './style';
+import { StuList } from '../../../../Atom/Atoms';
+import { useRecoilValue } from 'recoil';
 
 interface Props {
   onClose: () => void;
@@ -12,13 +14,14 @@ interface Props {
 
 export default function Assignment({ onClose, modifyId, userId }: Props) {
   const router = useRouter();
-
+  const stuList = useRecoilValue(StuList);
+  const user = stuList.find(item => item.id === userId);
   const { fetch } = useFetch({
     url: `client/${modifyId}/co-worker`,
     method: 'delete',
     onSuccess: () => {
       onClose();
-      router.push(`/${modifyId}`)
+      router.reload();
     },
   });
 
@@ -31,7 +34,7 @@ export default function Assignment({ onClose, modifyId, userId }: Props) {
             <ErrorIcon />
             <div>
               <h4>정말 삭제하실 건가요?</h4>
-              <p>공동작업자 리스트에서 삭제됩니다.</p>
+              <p>{user?.name}이(가) 공동작업자 리스트에서 삭제됩니다.</p>
             </div>
           </S.Title>
           <S.ButtonWrapper>

--- a/src/components/MyServiceList/Modify/index.tsx
+++ b/src/components/MyServiceList/Modify/index.tsx
@@ -180,13 +180,21 @@ export default function ModifyMyService({ modifyId }: { modifyId: string }) {
           />
         );
       case 'assignment':
+        if (serviceRetrieveModal !== 'list') {
+        }
         return (
-          <Assignment onClose={closeModal} modifyId={modifyId} userId={stuId} />
+          <Assignment
+            onClose={closeModal}
+            modifyId={modifyId}
+            userId={stuId}
+          />
         );
     }
 
     switch (serviceDeleteModal) {
       case 'assignment':
+        if (serviceRetrieveModal !== 'list') {
+        }
         return (
           <DeleteAssignment
             onClose={closeModal}
@@ -199,7 +207,7 @@ export default function ModifyMyService({ modifyId }: { modifyId: string }) {
     switch (serviceRetrieveModal) {
       case 'list':
         return (
-          <ServiceCoWorkersList onClose={closeModal} modifyId={modifyId} />
+          <ServiceCoWorkersList onClose={closeModal} modifyId={modifyId} setStuId={setStuId}/>
         );
     }
   };
@@ -408,7 +416,7 @@ export default function ModifyMyService({ modifyId }: { modifyId: string }) {
               </S.Profile>
               <S.Select
                 id="role"
-                onChange={(event) => {
+                onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                   roleSwitcher(event, member.id);
                 }}
                 value={'coworker'}

--- a/src/components/ServiceCo-WorkerList/Assignment/index.tsx
+++ b/src/components/ServiceCo-WorkerList/Assignment/index.tsx
@@ -35,7 +35,7 @@ export default function Assignment({ onClose, modifyId }: Props) {
             <ErrorIcon />
             <div>
               <h4>정말 공동작업자로 추가하실 건가요?</h4>
-              <p>소유자 권한을 양도하면 모든 권한을 양도하게 됩니다.</p>
+              <p>공동작업자 목록에 추가됩니다.</p>
             </div>
           </S.Title>
           <S.ButtonWrapper>

--- a/src/components/ServiceCo-WorkerList/index.tsx
+++ b/src/components/ServiceCo-WorkerList/index.tsx
@@ -12,6 +12,7 @@ import * as S from './style';
 import * as SVG from '../../../public/svg';
 import useFetch from '../../hooks/useFetch';
 import { toast } from 'react-toastify';
+import { useRouter } from 'next/router';
 
 interface Props {
   onClose: () => void;
@@ -20,6 +21,7 @@ interface Props {
 }
 
 export default function ServiceOwnerList({ onClose, userId, modifyId }: Props) {
+  const router = useRouter();
   const search = useRecoilValue(Search);
   const stuList = useRecoilValue(StuList);
 
@@ -27,6 +29,7 @@ export default function ServiceOwnerList({ onClose, userId, modifyId }: Props) {
     url: `client/${modifyId}/co-worker`,
     method: 'patch',
     onSuccess: () => {
+      router.reload();
       onClose();
     },
     onFailure:(error) => {
@@ -63,11 +66,11 @@ export default function ServiceOwnerList({ onClose, userId, modifyId }: Props) {
                 <th>번호</th>
               </S.TR>
             </thead>
-            <S.TBody>
+            <tbody>
               {stuList
                 .filter((e) => e.name?.includes(search) && e.id !== userId)
                 .map((e, idx) => (
-                  <tr key={idx}>
+                  <S.TR key={idx}>
                     <td>{e.name}</td>
                     <td>{e.grade}</td>
                     <td>{e.classNum}</td>
@@ -82,9 +85,9 @@ export default function ServiceOwnerList({ onClose, userId, modifyId }: Props) {
                         추가하기
                       </button>
                     </td>
-                  </tr>
+                  </S.TR>
                 ))}
-            </S.TBody>
+            </tbody>
           </S.Table>
         </S.TableWrapper>
       </S.Container>

--- a/src/components/ServiceCo-WorkerList/style.ts
+++ b/src/components/ServiceCo-WorkerList/style.ts
@@ -73,6 +73,7 @@ export const TR = styled.tr`
   font-size: 14px;
   line-height: 17px;
   color: #1c1c1c;
+  border-top: 1px solid #e4e4e4;
 
   th {
     font-weight: 500;
@@ -102,11 +103,5 @@ export const TR = styled.tr`
         padding: 8px;
       }
     }
-  }
-`;
-
-export const TBody = styled.tbody`
-  tr {
-    border-top: 1px solid #e4e4e4;
   }
 `;


### PR DESCRIPTION
## 💡 배경 및 개요
공동작업자를 8명 이상 추가 시에는 공동작업자 목록에서 확인해야하는데 확인하는 목록 모달에서 삭제 혹은 소유자 위임을 하게 되면 오류가 뜨는 현상이 발생하여 이를 고치고, 학생 리스트디자인이 누가봐도 잘못되어 있었기에 디자인적 수정도 하게 되었습니다.
<img width="714" alt="스크린샷 2024-07-11 오후 6 20 18" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/129853254/91ac25b9-f5d9-47d8-bec1-40b4abf30aab">

<img width="441" alt="스크린샷 2024-07-11 오후 6 22 04" src="https://github.com/GSM-MSG/GAuth-FrontEnd/assets/129853254/d179f97f-33f3-4498-9508-c4632805c592">

Resolves: #221

## 📃 작업내용
공동작업자 목록 모달에 유저의 Id로 설정할 수 있도록 관련 함수를 인수로 보냈고, 잘못 사용되고있는 스타일 컴포넌트를 삭제하였습니다.

## 🙋‍♂️ 리뷰노트
유저를 설정할 수 있도록 관련 함수를 보내면 간단하게 해결할 수 있었던 것을, 컴포넌트를 불러오는 데 문제가 있다고 생각하며 잘못된 접근 방식으로 이슈를 해결하려고 하여 골머리를 썩혔습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?